### PR TITLE
Improve status check

### DIFF
--- a/jackrabbit.sh
+++ b/jackrabbit.sh
@@ -4,9 +4,6 @@
 # Short-Description: Start/stop Jackrabbit JCR server.
 #
 # Description:       This relies on a PID file to check if Jackrabbit is running.
-#                    If you kill Jackrabbit without removing the PID file, you
-#                    will not be able to start Jackrabbit with this script until
-#                    you manually remove the PID file.
 #                    Edit the variables below to configure Jackrabbit
 #                    Depending on the storage backend, you might want to adjust
 #                    the required start / stop lines.
@@ -57,8 +54,13 @@ LOGFILE=$BASEDIR/jackrabbit.log
 # Uncomment to debug the script
 #set -x
 
+is_started() {
+    curl -s "http://$JACKRABBIT_HOST:$JACKRABBIT_PORT" |grep "Jackrabbit" > /dev/null
+    return $?
+}
+
 do_start() {
-    if [ ! -f $PIDFILE ]; then
+    if ! is_started; then
         cd $BASEDIR
         nohup java $MEMORY $MANAGEMENT -jar $JACKRABBIT_JAR -h $JACKRABBIT_HOST -p $JACKRABBIT_PORT >> $LOGFILE 2>&1 & echo $! > $PIDFILE
         # Wait until the server is ready (from an idea of Christoph Luehr)
@@ -70,10 +72,14 @@ do_start() {
 }
 
 do_stop() {
-    if [ -f $PIDFILE ]; then
-        kill $(cat $PIDFILE)
-        rm $PIDFILE
-        echo "Jackrabbit stopped"
+    if is_started; then
+        if [ -f $PIDFILE ]; then
+            kill $(cat $PIDFILE)
+            rm $PIDFILE
+            echo "Jackrabbit stopped"
+        else
+            echo "pid not found"
+        fi
     else
         echo "Jackrabbit is not running"
     fi
@@ -81,8 +87,13 @@ do_stop() {
 }
 
 do_status() {
-    if [ -f $PIDFILE ]; then
-        echo "Jackrabbit is running [ pid = " $(cat $PIDFILE) "]"
+    if is_started; then
+        echo "Jackrabbit is running \c"
+        if [ -f $PIDFILE ]; then
+            echo "[ pid = " $(cat $PIDFILE) "]"
+        else
+            echo "[ pid not found ]"
+        fi
     else
         echo "Jackrabbit is not running"
         exit 3


### PR DESCRIPTION
My initial problem is that after a crash, the PID file is not removed and jackrabbit won't start at boot.

I added a `is_started` function that makes a curl call and test if the response contains the "Jackrabbit" word. Not very elegant but that's the best solution I found to test if : 
- something is running on the jackrabbit port
- it is jackrabbit

This PR was inspired by https://github.com/sixty-nine/Jackrabbit-startup-script/issues/2
